### PR TITLE
add kcs directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 /config.py
 /data/_*.json
 
+# Don't include the static files from kcs directory.
+/kcs


### PR DESCRIPTION
Why upload SWF assets to a git when you can just use a command to download them anyway now?